### PR TITLE
feat: fetch api backstage token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysdig/backstage-plugin-sysdig",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
@@ -25,6 +25,7 @@
   "dependencies": {
     "@backstage/core-components": "^0.14.0",
     "@backstage/core-plugin-api": "^1.9.0",
+    "@backstage/plugin-catalog-react": "^1.13.0",
     "@backstage/theme": "^0.5.1",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
@@ -39,10 +40,14 @@
     "@backstage/core-app-api": "^1.12.0",
     "@backstage/dev-utils": "^1.0.27",
     "@backstage/test-utils": "^1.5.0",
-    "@testing-library/jest-dom": "^5.10.1",
+    "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^14.0.0",
-    "msw": "^1.0.0"
+    "@types/jest": "^29.5.13",
+    "@types/react": "^18.3.9",
+    "@types/react-dom": "^18.3.0",
+    "msw": "^1.0.0",
+    "typescript": "^5.6.2"
   },
   "files": [
     "config.d.ts",

--- a/src/api/SysdigApi.ts
+++ b/src/api/SysdigApi.ts
@@ -1,0 +1,19 @@
+/* src/api.ts */
+import { createApiRef } from "@backstage/core-plugin-api";
+
+export interface SysdigApi {
+  fetchVulnRuntime: <T = any>(filters?: string, init?: RequestInit) => Promise<T>;
+  fetchVulnRegistry: <T = any>(
+    filters?: string,
+    init?: RequestInit,
+  ) => Promise<T>;
+  fetchVulnPipeline: <T = any>(
+    fitlers?: string,
+    init?: RequestInit,
+  ) => Promise<T>;
+  fetchInventory: <T = any>(filters?: string, init?: RequestInit) => Promise<T>;
+}
+
+export const sysdigApiRef = createApiRef<SysdigApi>({
+  id: "plugin.sysdig.service",
+});

--- a/src/api/SysdigApiClient.ts
+++ b/src/api/SysdigApiClient.ts
@@ -1,0 +1,59 @@
+import { ConfigApi, FetchApi } from "@backstage/core-plugin-api";
+import { SysdigApi } from "./SysdigApi";
+import {
+  API_INVENTORY,
+  API_PROXY_BASE_PATH,
+  API_VULN_PIPELINE,
+  API_VULN_REGISTRY,
+  API_VULN_RUNTIME,
+} from "../lib";
+
+export class SysdigApiClient implements SysdigApi {
+  private readonly fetchApi: FetchApi;
+  private readonly configApi: ConfigApi;
+  private readonly baseUrl: string;
+
+  constructor(options: { configApi: ConfigApi; fetchApi: FetchApi }) {
+    this.configApi = options.configApi;
+    this.fetchApi = options.fetchApi;
+    this.baseUrl = this.configApi.getString("backend.baseUrl");
+  }
+
+  private async fetch<T>(endpoint: string, init?: RequestInit): Promise<T> {
+    const uri = `${this.baseUrl}${API_PROXY_BASE_PATH}${endpoint}`;
+
+    const response = await this.fetchApi.fetch(uri, init);
+
+    if (!response.ok) throw new Error(response.statusText);
+
+    return await response.json();
+  }
+
+  async fetchVulnRuntime<T = any>(
+    filters?: string,
+    init?: RequestInit,
+  ): Promise<T> {
+    return await this.fetch<T>(`${API_VULN_RUNTIME}${filters}`, init);
+  }
+
+  async fetchVulnRegistry<T = any>(
+    filters?: string,
+    init?: RequestInit,
+  ): Promise<T> {
+    return await this.fetch<T>(`${API_VULN_REGISTRY}${filters}`, init);
+  }
+
+  async fetchVulnPipeline<T = any>(
+    filters?: string,
+    init?: RequestInit,
+  ): Promise<T> {
+    return await this.fetch<T>(`${API_VULN_PIPELINE}${filters}`, init);
+  }
+
+  async fetchInventory<T = any>(
+    filters?: string,
+    init?: RequestInit,
+  ): Promise<T> {
+    return await this.fetch<T>(`${API_INVENTORY}${filters}`, init);
+  }
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,2 @@
+export * from "./SysdigApi";
+export * from "./SysdigApiClient";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -13,12 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createPlugin, createRoutableExtension } from '@backstage/core-plugin-api';
+import { configApiRef, createApiFactory, createPlugin, createRoutableExtension, fetchApiRef } from '@backstage/core-plugin-api';
+import { SysdigApiClient, sysdigApiRef } from './api';
 
 import { rootRouteRef } from './routes';
 
 export const sysdigPlugin = createPlugin({
   id: 'sysdig',
+  apis: [
+    createApiFactory({
+      api: sysdigApiRef,
+      deps: { configApi: configApiRef, fetchApi: fetchApiRef},
+      factory: ({ configApi, fetchApi }) => new SysdigApiClient({ configApi, fetchApi})
+    })
+  ],
   routes: {
     root: rootRouteRef,
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2019",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -56,7 +56,13 @@
     "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist-types/src",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "dist-types",                                   /* Specify an output folder for all emitted files. */
+    "rootDir": "src",
+
+    "emitDeclarationOnly": true, // Optional: Only emit declaration files without compiling JavaScript
+    "skipLibCheck": true, // Optional: Skips checking types of .d.ts files
+    "moduleResolution": "node",
+    
     // "removeComments": true,                           /* Disable emitting comments. */
     "noEmit": false,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -106,5 +112,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
# Description

I didn’t see any documentation for contributing, but I decided to create a PR that would solve #16.

## Changes Made 

I have added a `SysdigApiClient` to the plugin that all the components use when calling the proxy. The `SysdigApiClient` uses `fetchApi.fetch()` to include a Backstage token, so it’s possible to use the default credentials for the proxy.

In the `SysdigApiClient`, I have defined 4 methods based on the 4 constant API endpoints defined in `/lib/endpoints.ts`. I’m not that familiar with the Sysdig API, so if it makes sense to change the methods, let me know.

## Testing

I have tried to test the changes with our own Backstage application, and everything seems to be working fine. It was, however, a bit difficult to test locally since the `dev/index.ts` file is missing and there are no tests defined for the components.