### PR TITLE
fix Updating the secure path for the different scan links and the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ proxy:
 
 ...
 
-+ sysdig:
-+   endpoint: ${SYSDIG_SECURE_ENDPOINT}
-+   backlink: https://... # Optional override base link for backlinks. Must end in '/'.
++sysdig:
++  endpoint: ${SYSDIG_SECURE_ENDPOINT}
++  backlink: https://... # Optional override base link for backlinks. Must end in '/'.
 ```
 
 - Set the environment variable `SYSDIG_SECURE_ENDPOINT` to your Sysdig Secure Endpoint.

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -24,18 +24,20 @@ export const API_INVENTORY = "/api/cspm/v1/inventory/resources";
  */
 let DEFAULT_BACKLINK_BASE: string = "https://secure.sysdig.com/"
 
-const BACKLINKS: Record<string, string> = {
+let SECURE_PREFIX: string = "secure/#/";
+
+const SECURE_BACKLINKS: Record<string, string> = {
     // Backlink path to Vulnerability Management at Runtime
-    "vm-runtime": "#/vulnerabilities/runtime/",
+    "vm-runtime": SECURE_PREFIX + "vulnerabilities/runtime/",
 
     // Backlink path to Vulnerability Management at Registry
-    "vm-registry": "#/vulnerabilities/registry/",
+    "vm-registry": SECURE_PREFIX + "vulnerabilities/registry/",
 
     // Backlink path to Vulnerability Management at Pipeline
-    "vm-pipeline": "#/vulnerabilities/pipeline/",
+    "vm-pipeline": SECURE_PREFIX + "vulnerabilities/pipeline/",
 
     // Backlink path to Inventory
-    "inventory": "#/inventory"
+    "inventory": SECURE_PREFIX + "inventory"
 }
 
 export function getBacklink(endpoint: string | undefined, backlink: string | undefined, section: string) : string {
@@ -47,7 +49,7 @@ export function getBacklink(endpoint: string | undefined, backlink: string | und
         backlink_base = endpoint
     }
 
-    let backlink_section : string = BACKLINKS[section];
+    let backlink_section : string = SECURE_BACKLINKS[section];
 
     if (backlink_section === undefined) {
         return "";


### PR DESCRIPTION
## Description

* Updating the links from the UI that are pointing to the incorrect Sysdig URL. They are missing the `/secure/#/` prefix for the secure products
* Updated the README for the `sysdig` section so we know that it is NOT a child of the `proxy` configuration. If not defined using the DEFAULT_BACKLINK_BASE var that will also set incorrect follow-up links

## Example

![image](https://github.com/user-attachments/assets/d8764d49-6d9a-4482-accb-adc86435a419)
