### PR TITLE
chore: add CLAUDE.md and bump version to 1.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysdig/backstage-plugin-sysdig",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "main": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` referencing `AGENTS.md` so Claude Code automatically loads project guidelines at the start of every session (prevents missing release steps like version bumps)
- Bump `package.json` version from `1.4.1` → `1.5.0` to trigger the automated release workflow for features merged since `1.4.0`

## Why

Without a `CLAUDE.md`, Claude Code does not read `AGENTS.md` automatically and can miss project-specific steps (e.g., the manual version bump required before a release).

## Test plan

- [ ] Confirm `just test` passes
- [ ] Confirm `just lint` passes
- [ ] Confirm release workflow triggers on merge to `main`