### PR TITLE
chore: bump dependencies 2026-04-07

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765270179,
-        "narHash": "sha256-g2a4MhRKu4ymR4xwo+I+auTknXt/+j37Lnf0Mvfl1rE=",
+        "lastModified": 1775464765,
+        "narHash": "sha256-nex6TL2x1/sVHCyDWcvl1t/dbTedb9bAGC4DLf/pmYk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "677fbe97984e7af3175b6c121f3c39ee5c8d62c9",
+        "rev": "83e29f2b8791f6dec20804382fcd9a666d744c07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated dependency update. NOTE: `yarn backstage-cli versions:bump` could not run because the nix devshell is broken — `nodePackages` has been removed from nixpkgs. Only `flake.lock` was updated. The flake.nix needs to be updated to remove `nodePackages.typescript-language-server` and `nodePackages.node-gyp` references.